### PR TITLE
Build Android application with errors

### DIFF
--- a/lib/presentation/home_marketplace_feed/widgets/enhanced_location_selector_widget.dart
+++ b/lib/presentation/home_marketplace_feed/widgets/enhanced_location_selector_widget.dart
@@ -188,7 +188,6 @@ class _LocationPickerModalState extends State<_LocationPickerModal> {
     try {
       final result = await _places.findAutocompletePredictions(
         input,
-        sessionToken: _sessionToken,
         countries: ['IN'],
       );
       setState(() {


### PR DESCRIPTION
Remove `sessionToken` parameter from `_places.findAutocompletePredictions` to fix build error.

The `sessionToken` parameter is no longer supported by the `findAutocompletePredictions` method, causing a "No named parameter" build error.