### PR TITLE
Fix dropdown type mismatch in android build

### DIFF
--- a/lib/presentation/create_listing/create_listing.dart
+++ b/lib/presentation/create_listing/create_listing.dart
@@ -230,8 +230,8 @@ class _CreateListingScreenState extends State<CreateListingScreen> {
                       value: _selectedCategoryId,
                       decoration: const InputDecoration(labelText: 'Category *'),
                       items: _categories
-                          .map((cat) => DropdownMenuItem(
-                                value: cat['id'],
+                          .map((cat) => DropdownMenuItem<String>(
+                                value: cat['id'] as String,
                                 child: Text(cat['name']),
                               ))
                           .toList(),


### PR DESCRIPTION
Fixes a type mismatch error in the category dropdown.

The build failed with `Error: The argument type 'List<DropdownMenuItem<Object>>' can't be assigned to the parameter type 'List<DropdownMenuItem<String>>?'`. This PR resolves the issue by explicitly typing `DropdownMenuItem` as `String` and casting the `cat['id']` value to `String` to match the expected type.