### PR TITLE
Fix android build min sdk error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         applicationId "com.khilonjiya.marketplace"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Update Android `minSdkVersion` to 23 to resolve build failure caused by library requirements.