### PR TITLE
Build android application with errors

### DIFF
--- a/lib/presentation/registration_screen/registration_screen.dart
+++ b/lib/presentation/registration_screen/registration_screen.dart
@@ -392,6 +392,22 @@ class _RegistrationScreenState extends State<RegistrationScreen>
     }
   }
 
+  // --- Added for build error fix: UI-only, no backend logic changed ---
+  Widget _buildProfileImagePicker() {
+    // Reuse the profile photo section for design
+    return _buildProfilePhotoSection();
+  }
+
+  Widget _buildForm() {
+    // Reuse the registration form for design
+    return _buildRegistrationForm();
+  }
+
+  Widget _buildTermsAndConditions() {
+    // Reuse the terms checkbox for design
+    return _buildTermsCheckbox();
+  }
+
   @override
   void dispose() {
     _fadeController.dispose();


### PR DESCRIPTION
Add missing UI-building methods to `_RegistrationScreenState` to resolve build errors.

The build was failing because methods like `_buildProfileImagePicker`, `_buildForm`, and `_buildTermsAndConditions` were called but not defined in `_RegistrationScreenState`. This PR adds these methods, which simply delegate to existing UI-building functions, thereby fixing the compilation error without altering the application's existing design or functionality.