### PR TITLE
Fix android build type mismatch error

### DIFF
--- a/lib/presentation/home_marketplace_feed/home_marketplace_feed.dart
+++ b/lib/presentation/home_marketplace_feed/home_marketplace_feed.dart
@@ -40,11 +40,11 @@ class _HomeMarketplaceFeedState extends State<HomeMarketplaceFeed> {
       final listRes = await supabase.client.from('listings').select('*, categories(name)');
       final listings = List<Map<String, dynamic>>.from(listRes);
       setState(() {
-        _categories = [{'name': 'All', 'icon': Icons.apps, 'color': Colors.green}] + categories.map((c) => {
+        _categories = [{'name': 'All', 'icon': Icons.apps, 'color': Colors.green}] + List<Map<String, dynamic>>.from(categories.map((c) => {
           'name': c['name'],
           'icon': Icons.category,
           'color': Colors.green
-        }).toList();
+        }).toList());
         _listings = listings;
         _isLoadingPremium = false;
         _isLoadingFeed = false;


### PR DESCRIPTION
Explicitly cast list of categories to `List<Map<String, dynamic>>` to resolve a type assignment error during Android build.