### PR TITLE
Resolve gradle build failures and missing resources

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,10 +51,6 @@ android {
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         
-        // Add these configurations to fix resource extraction issues
-        ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
-        }
     }
 
     buildTypes {


### PR DESCRIPTION
Remove conflicting `ndk.abiFilters` to resolve Gradle build error.