### PR TITLE
Build android application failed

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -17,10 +17,6 @@ workflows:
         script: |
           flutter pub get
 
-      - name: Generate Native Splash
-        script: |
-          flutter pub run flutter_native_splash:create
-
       - name: Clean and Build Debug APK with .env loaded
         script: |
           flutter clean

--- a/flutter_native_splash.yaml
+++ b/flutter_native_splash.yaml
@@ -1,9 +1,0 @@
-flutter_native_splash:
-  color: "#ffffff"
-  image: assets/images/splash/splash.png
-  android: true
-  ios: true
-  web: false
-  android_gravity: center
-  ios_content_mode: center
-  fullscreen: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
-  flutter_native_splash: ^2.3.10
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Remove flutter_native_splash package and related configurations to resolve build failures.

The `flutter_native_splash` package was identified as a potential cause for the Android build failing to produce an APK.